### PR TITLE
[HOTFIX] Fixes issue with setup.cfg where a comma is missing

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -51,7 +51,7 @@ packages = pythonrepo
 zip_safe = true
 py_modules = pythonrepo
 test_suite = tests
-python_requires = >=2.7, !=3.0.*, !=3.1.*, !=3.2.* !=3.15.*
+python_requires = >=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.15.*
 setup_requires =
   setuptools>=45.0.0
   wheel>=0.37.0


### PR DESCRIPTION
This is a minor Hotfix to correct a typo in setup.cfg that broke CI.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
	- Updated the version specification syntax in the configuration file for improved clarity and correctness.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->